### PR TITLE
fix: Create a single base Arcjet client to share cache, etc

### DIFF
--- a/app/attack/test/route.ts
+++ b/app/attack/test/route.ts
@@ -1,24 +1,17 @@
-import arcjet, { shield } from "@arcjet/next";
+import arcjet, { shield } from "@/lib/arcjet";
 import { NextResponse } from "next/server";
 
 // Opt out of caching
 export const dynamic = "force-dynamic";
 
-// Create an Arcjet instance outside of the handler function
-const aj = arcjet({
-  // Get your site key from https://app.arcjet.com
-  // and set it as an environment variable rather than hard coding.
-  // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.ARCJET_KEY,
-  rules: [
-    // Shield detects suspicious behavior, such as SQL injection and cross-site
-    // scripting attacks.
-    shield({
-      mode: "LIVE",
-    }),
-    // .. you can chain multiple rules
-  ],
-});
+// Add rules to the base Arcjet instance outside of the handler function
+const aj = arcjet.withRule(
+  // Shield detects suspicious behavior, such as SQL injection and cross-site
+  // scripting attacks.
+  shield({
+    mode: "LIVE"
+  })
+);
 
 export async function GET(req: Request) {
   // The protect method returns a decision object that contains information

--- a/app/bots/test/route.ts
+++ b/app/bots/test/route.ts
@@ -1,23 +1,16 @@
-import arcjet, { detectBot } from "@arcjet/next";
+import arcjet, { detectBot } from "@/lib/arcjet";
 import { NextResponse } from "next/server";
 
 // Opt out of caching
 export const dynamic = "force-dynamic";
 
-// Create an Arcjet instance outside of the handler function
-const aj = arcjet({
-  // Get your site key from https://app.arcjet.com
-  // and set it as an environment variable rather than hard coding.
-  // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.ARCJET_KEY,
-  rules: [
-    detectBot({
-      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      block: ["AUTOMATED"], // blocks all automated clients
-    }),
-    // .. you can chain multiple rules
-  ],
-});
+// Add rules to the base Arcjet instance outside of the handler function
+const aj = arcjet.withRule(
+  detectBot({
+    mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    block: ["AUTOMATED"], // blocks all automated clients
+  })
+);
 
 export async function GET(req: Request) {
   // The protect method returns a decision object that contains information

--- a/app/rate-limiting/test/route.ts
+++ b/app/rate-limiting/test/route.ts
@@ -1,26 +1,20 @@
 import { auth } from "@/lib/auth";
 import { setRateLimitHeaders } from "@arcjet/decorate";
-import arcjet, { fixedWindow, shield } from "@arcjet/next";
+import arcjet, { fixedWindow, shield } from "@/lib/arcjet";
 import type { Session } from "next-auth";
 import { NextResponse } from "next/server";
 
 // Opt out of caching
 export const dynamic = "force-dynamic";
 
-const aj = arcjet({
-  // Get your site key from https://app.arcjet.com and set it as an environment
-  // variable rather than hard coding. See:
-  // https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.ARCJET_KEY,
-  rules: [
-    // Shield detects suspicious behavior, such as SQL injection and cross-site
-    // scripting attacks. We want to ru nit on every request
-    shield({
-      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-    }),
-    // .. you can chain multiple rules
-  ],
-});
+// Add rules to the base Arcjet instance outside of the handler function
+const aj = arcjet.withRule(
+  // Shield detects suspicious behavior, such as SQL injection and cross-site
+  // scripting attacks. We want to ru nit on every request
+  shield({
+    mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+  })
+);
 
 // Returns ad-hoc rules depending on whether the session is present. You could
 // inspect more details about the session to dynamically adjust the rate limit.

--- a/app/signup/test/route.ts
+++ b/app/signup/test/route.ts
@@ -1,39 +1,34 @@
 import { formSchema } from "@/lib/formSchema";
-import arcjet, { protectSignup } from "@arcjet/next";
+import arcjet, { protectSignup } from "@/lib/arcjet";
 import { NextResponse } from "next/server";
 
-const aj = arcjet({
-  // Get your site key from https://app.arcjet.com
-  // and set it as an environment variable rather than hard coding.
-  // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-  key: process.env.ARCJET_KEY,
-  rules: [
-    // Arcjet's protectSignup rule is a combination of email validation, bot
-    // protection and rate limiting. Each of these can also be used separately
-    // on other routes e.g. rate limiting on a login route. See
-    // https://docs.arcjet.com/get-started
-    protectSignup({
-      email: {
-        mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-        // Block emails that are disposable, invalid, or have no MX records
-        block: ["DISPOSABLE", "INVALID", "NO_MX_RECORDS"],
-      },
-      bots: {
-        mode: "LIVE",
-        // Block clients that we are sure are automated
-        block: ["AUTOMATED"],
-      },
-      // It would be unusual for a form to be submitted more than 5 times in 10
-      // minutes from the same IP address
-      rateLimit: {
-        // uses a sliding window rate limit
-        mode: "LIVE",
-        interval: "2m", // counts requests over a 10 minute sliding window
-        max: 5, // allows 5 submissions within the window
-      },
-    }),
-  ],
-});
+// Add rules to the base Arcjet instance outside of the handler function
+const aj = arcjet.withRule(
+  // Arcjet's protectSignup rule is a combination of email validation, bot
+  // protection and rate limiting. Each of these can also be used separately
+  // on other routes e.g. rate limiting on a login route. See
+  // https://docs.arcjet.com/get-started
+  protectSignup({
+    email: {
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      // Block emails that are disposable, invalid, or have no MX records
+      block: ["DISPOSABLE", "INVALID", "NO_MX_RECORDS"],
+    },
+    bots: {
+      mode: "LIVE",
+      // Block clients that we are sure are automated
+      block: ["AUTOMATED"],
+    },
+    // It would be unusual for a form to be submitted more than 5 times in 10
+    // minutes from the same IP address
+    rateLimit: {
+      // uses a sliding window rate limit
+      mode: "LIVE",
+      interval: "2m", // counts requests over a 10 minute sliding window
+      max: 5, // allows 5 submissions within the window
+    },
+  })
+);
 
 export async function POST(req: Request) {
   const json = await req.json();

--- a/lib/arcjet.ts
+++ b/lib/arcjet.ts
@@ -1,0 +1,15 @@
+import arcjet, { shield, detectBot, fixedWindow, protectSignup } from "@arcjet/next";
+
+// Re-export the rules to simplify imports inside handlers
+export { shield, detectBot, fixedWindow, protectSignup };
+
+// Create a base Arcjet instance for use by each handler
+export default arcjet({
+  // Get your site key from https://app.arcjet.com
+  // and set it as an environment variable rather than hard coding.
+  // See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
+  key: process.env.ARCJET_KEY,
+  rules: [
+    // You can include one or more rules base rules
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@arcjet/decorate": "^1.0.0-alpha.15",
-    "@arcjet/next": "latest",
+    "@arcjet/next": "^1.0.0-alpha.15",
     "@hookform/resolvers": "^3.6.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",


### PR DESCRIPTION
For full-fledged apps like this, we should show the proper way to construct and use a base arcjet client. The client-per-handler is only used for simple snippets in our docs. 