### PR TITLE
chore(ci): Group all packages together for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 version: 2
 updates:
-  # Dependencies in our packages
-
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -14,6 +12,19 @@ updates:
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
+    groups:
+      dependencies-major:
+        update-types:
+          - major
+      dependencies-minor:
+        update-types:
+          - minor
+          - patch
+      # Arcjet packages are grouped alone due to not being major/minor/patch yet
+      arcjet-js:
+        patterns:
+          - "arcjet"
+          - "@arcjet/*"
     ignore:
       - dependency-name: eslint
         versions: [">=9"]


### PR DESCRIPTION
This creates groups of dependencies so we can merge the dependabot PRs easier.